### PR TITLE
WRN-872-more-assay-slims

### DIFF
--- a/ontology/manual_slims.py
+++ b/ontology/manual_slims.py
@@ -14,6 +14,7 @@ manual_slims = {
         'OBI:0001266': ['DNA methylation'],  # DNA methylation profiling by high throughput sequencing assay
         'OBI:0002117': ['genetic profiling'],  # WGS assay
         'OBI:0000435': ['genetic profiling'],  # Genotyping array
+        'OBI:0000626': ['genetic profiling'],  # DNA sequencing assay
         'OBI:0003133': ['CRISPR screens'],  # cas mediated mutagenesis
         'OBI:0003659': ['CRISPR screens'],  # in vitro CRISPR screen assay
         'OBI:0003660': ['CRISPR screens'],  # in vitro CRISPR screen using single-cell RNA-seq

--- a/ontology/ntr_terms.py
+++ b/ontology/ntr_terms.py
@@ -53,6 +53,10 @@ ntr_assays = {
         "name": "proximity ligation-assisted ChIP-seq",
         "preferred_name": "PLAC-seq",
     },
+    "NTR:0000520": {
+        "assay": ["CRISPR screens"],
+        "name": "CRISPR screen"
+    },
     "NTR:0000538": {
         "assay": ["RNA structure"],
         "name": "in vivo click light activated structural examination of RNA",
@@ -140,6 +144,18 @@ ntr_assays = {
     "NTR:0000745": {
         "name": "single nucleus methylation chromatin conformation capture seq",
         "assay": ["multiome"]
+    },
+    "NTR:0000761": {
+        "name": "spatial transcriptomics",
+        "assay": ["gene expression"]
+    },
+    "NTR:000789": {
+        "name": "single cell massively parallel reporter assay",
+        "assay": ["reporter"]
+    },
+    "NTR:0000787": {
+        "name": "blended genome exome sequencing",
+        "assay": ["genetic profiling"]
     },
 }
 


### PR DESCRIPTION
Note that NTR:000789 is intentionally only 6 digits long, not accidental.

It was submitted this way on the portal https://data.igvf.org/assay-terms/NTR_000789/ so to have the mapping work correctly I need to follow the portal term. 

(We could modify the portal term but it was already released so I prefer to just match it in the code.)